### PR TITLE
replace (bad) unix epochs with Datetime objects

### DIFF
--- a/HoerAPI.php
+++ b/HoerAPI.php
@@ -1,5 +1,32 @@
 <?php
 namespace HoerAPI;
+use Datetime;
+use DateTimeZone;
+
+function parseDate($date, $zone = null)
+{
+    static $Local, $GMT;
+
+    switch (strtolower($zone)) {
+        case null:
+        case 'local':
+        case 'default':
+            if (!isset($Local)) {
+                 $Local = new DateTimeZone('Europe/Berlin');
+            }
+            $zone = $Local;
+            break;
+        case 'gmt':
+            if (!isset($GMT)) {
+                 $GMT = new DateTimeZone('GMT');
+            }
+            $zone = $GMT;
+            break;
+        default:
+            return null;
+    }
+    return new Datetime($date, $zone);
+}
 
 class HoerAPI
 {

--- a/HoerAPI/PodcastDeletedItem.php
+++ b/HoerAPI/PodcastDeletedItem.php
@@ -7,6 +7,6 @@ class PodcastDeletedItem {
 
     public function __construct(array $data){
         $this->event_id = (int) $data['event_ID'];
-        $this->deldate = strtotime($data['deldate']);
+        $this->deldate = parseDate($data['deldate']);
     }
 }

--- a/HoerAPI/PodcastEpisodeItem.php
+++ b/HoerAPI/PodcastEpisodeItem.php
@@ -16,12 +16,12 @@ class PodcastEpisodeItem {
 
     public function __construct(array $data) {
         $this->id = (int) $data['ID'];
-        $this->date = strtotime($data['post_date']);
-        $this->date_gmt = strtotime($data['post_date_gmt']);
+        $this->date = parseDate($data['post_date']);
+        $this->date_gmt = parseDate($data['post_date_gmt'], 'gmt');
         $this->title = $data['post_title'];
         $this->name = $data['post_name'];
-        $this->modified = strtotime($data['post_modified']);
-        $this->modified_gmt = strtotime($data['post_modified_gmt']);
+        $this->modified = parseDate($data['post_modified']);
+        $this->modified_gmt = parseDate($data['post_modified_gmt'], 'gmt');
         $this->link = $data['post_link'];
         $this->mediaurl = $data['post_mediaurl'];
         $this->commentlink = $data['post_commentlink'];

--- a/HoerAPI/PodcastLiveItem.php
+++ b/HoerAPI/PodcastLiveItem.php
@@ -23,7 +23,7 @@ class PodcastLiveItem {
         $this->title = $data['title'];
         $this->url = $data['url'];
         $this->streamurl = $data['streamurl'];
-        $this->livedate = strtotime($data['livedate']);
+        $this->livedate = parseDate($data['livedate']);
         $this->duration = (int) $data['duration'];
         $this->twittered = !!$data['twittered'];
     }


### PR DESCRIPTION
Regular date entries in `hoersuppe API` replies are in untagged format but are in "Europe/Berlin" timezone. Both date entry types (normal and 'gmt') are interpreted by `strtotime` as values in localtime for PHP host, resulting in AT LEAST ONE entry being false.

This change mirrors behavior of `hoerapi.py v2.0` plus [pull/4](https://github.com/hoersuppe/hoerapi.py/pull/4) patch.